### PR TITLE
Auto turn signal de-activation + persistent brakes lights when stopped

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,3 +1,7 @@
+local isIndicatorActive = false
+local previousHeading = 0
+local headingCheckThreshold = 70 -- Degrees needed to turn before auto-deactivating indicator
+
 local function isIndicating(vehicle, type)
   if not Entity(vehicle).state.indicate then return false end
   local state = Entity(vehicle).state.indicate
@@ -15,12 +19,46 @@ local function indicate(type)
   local vehicle = GetVehiclePedIsIn(ped)
   
   local value = {}
-  if type == "left" and not isIndicating(vehicle, "left") then value = {false, true}
-  elseif type == "right" and not isIndicating(vehicle, "right") then value = {true, false}
-  elseif type == "hazards" and not isIndicating(vehicle, "hazards") then value = {true, true} 
-  else value = {false, false} end
+  if type == "left" and not isIndicating(vehicle, "left") then 
+    value = {false, true}
+    isIndicatorActive = "left"
+    previousHeading = GetEntityHeading(vehicle)
+  elseif type == "right" and not isIndicating(vehicle, "right") then 
+    value = {true, false}
+    isIndicatorActive = "right"
+    previousHeading = GetEntityHeading(vehicle)
+  elseif type == "hazards" and not isIndicating(vehicle, "hazards") then 
+    value = {true, true}
+    isIndicatorActive = "hazards"
+  else 
+    value = {false, false}
+    isIndicatorActive = false
+  end
 
   TriggerServerEvent("jg-vehicleindicators:server:set-state", VehToNet(vehicle), value)
+end
+
+local function checkTurnCompletion()
+  if not isIndicatorActive or isIndicatorActive == "hazards" then return end
+  
+  local ped = PlayerPedId()
+  if not IsPedInAnyVehicle(ped) then 
+    isIndicatorActive = false
+    return 
+  end
+  
+  local vehicle = GetVehiclePedIsIn(ped)
+  local currentHeading = GetEntityHeading(vehicle)
+  
+  local headingDiff = math.abs(currentHeading - previousHeading)
+  if headingDiff > 180 then
+    headingDiff = 360 - headingDiff
+  end
+  
+  if (isIndicatorActive == "left" and headingDiff >= headingCheckThreshold) or
+     (isIndicatorActive == "right" and headingDiff >= headingCheckThreshold) then
+    indicate("off")
+  end
 end
 
 AddStateBagChangeHandler("indicate", nil, function(bagName, key, data)
@@ -39,3 +77,33 @@ RegisterKeyMapping('indicate_right', 'Vehicle indicate right', 'keyboard', 'RIGH
 
 RegisterCommand("hazards", function() indicate("hazards") end)
 RegisterKeyMapping('hazards', 'Vehicle hazards', 'keyboard', 'UP')
+
+local brakeLightsOn = false
+
+Citizen.CreateThread(function()
+  while true do
+    Citizen.Wait(500)
+    checkTurnCompletion()
+  end
+end)
+
+Citizen.CreateThread(function()
+  while true do
+    Citizen.Wait(0)
+
+    local ped = PlayerPedId()
+    if IsPedInAnyVehicle(ped, false) then
+      local vehicle = GetVehiclePedIsIn(ped, false)
+
+      if GetPedInVehicleSeat(vehicle, -1) == ped then
+        local speed = GetEntitySpeed(vehicle) * 3.6
+
+        if speed < 1.0 and not isIndicatorActive then
+          SetVehicleBrakeLights(vehicle, true)
+        end
+      end
+    else
+      Citizen.Wait(1000)
+    end
+  end
+end)


### PR DESCRIPTION
All original functionality is in tact with the following added Features.

Brake Light Behavior at Low Speeds:
When the vehicle is moving under 1 km/h, brake lights are now automatically forced on to simulate realistic braking at stops.

Automatic Turn Signal Cancellation:
Left and right turn indicators now auto-cancel after completing a turn, based on a configurable heading change threshold.

Indicator Visibility at Stops:
When turn signals or hazard lights are active, forced brake lights are temporarily suppressed to ensure indicator lights remain clearly visible while the vehicle is stationary. Brake lights resume normal behavior once indicators are turned off.